### PR TITLE
Fix config parser issue in test_client

### DIFF
--- a/pyjiffy/test/test_client.py
+++ b/pyjiffy/test/test_client.py
@@ -189,43 +189,43 @@ class TestClient(TestCase):
 
         # Test exists/get/put
         for i in range(0, 1000):
-            self.assertEqual(b('!ok'), kv.put(str(i), str(i)))
+            self.assertEqual(b('!ok'), kv.put(b(str(i)), b(str(i))))
 
         for i in range(0, 1000):
             if getattr(kv, "exists", None) is not None:
-                self.assertTrue(kv.exists(str(i)))
-            self.assertEqual(b(str(i)), kv.get(str(i)))
+                self.assertTrue(kv.exists(b(str(i))))
+            self.assertEqual(b(str(i)), kv.get(b(str(i))))
 
         for i in range(1000, 2000):
             if getattr(kv, "exists", None) is not None:
-                self.assertFalse(kv.exists(str(i)))
-            self.assertEqual(b('!key_not_found'), kv.get(str(i)))
+                self.assertFalse(kv.exists(b(str(i))))
+            self.assertEqual(b('!key_not_found'), kv.get(b(str(i))))
 
         if getattr(kv, "num_keys", None) is not None:
             self.assertEqual(1000, kv.num_keys())
 
         # Test update
         for i in range(0, 1000):
-            self.assertEqual(b(str(i)), kv.update(str(i), str(i + 1000)))
+            self.assertEqual(b(str(i)), kv.update(b(str(i)), b(str(i + 1000))))
 
         for i in range(1000, 2000):
-            self.assertEqual(b('!key_not_found'), kv.update(str(i), str(i + 1000)))
+            self.assertEqual(b('!key_not_found'), kv.update(b(str(i)), b(str(i + 1000))))
 
         for i in range(0, 1000):
-            self.assertEqual(b(str(i + 1000)), kv.get(str(i)))
+            self.assertEqual(b(str(i + 1000)), kv.get(b(str(i))))
 
         if getattr(kv, "num_keys", None) is not None:
             self.assertEqual(1000, kv.num_keys())
 
         # Test remove
         for i in range(0, 1000):
-            self.assertEqual(b(str(i + 1000)), kv.remove(str(i)))
+            self.assertEqual(b(str(i + 1000)), kv.remove(b(str(i))))
 
         for i in range(1000, 2000):
-            self.assertEqual(b('!key_not_found'), kv.remove(str(i)))
+            self.assertEqual(b('!key_not_found'), kv.remove(b(str(i))))
 
         for i in range(0, 1000):
-            self.assertEqual(b('!key_not_found'), kv.get(str(i)))
+            self.assertEqual(b('!key_not_found'), kv.get(b(str(i))))
 
         if getattr(kv, "num_keys", None) is not None:
             self.assertEqual(0, kv.num_keys())
@@ -383,10 +383,10 @@ class TestClient(TestCase):
     #     try:
     #         kv = client.create("/a/file.txt", "local://tmp")
     #         for i in range(0, 2000):
-    #             self.assertEqual(b('!ok'), kv.put(str(i), str(i)))
+    #             self.assertEqual(b('!ok'), kv.put(b(str(i)), b(str(i))))
     #         self.assertEqual(4, len(client.fs.dstatus("/a/file.txt").data_blocks))
     #         for i in range(0, 2000):
-    #             self.assertEqual(b(str(i)), kv.remove(str(i)))
+    #             self.assertEqual(b(str(i)), kv.remove(b(str(i))))
     #         self.assertEqual(1, len(client.fs.dstatus("/a/file.txt").data_blocks))
     #     finally:
     #         client.disconnect()
@@ -407,8 +407,8 @@ class TestClient(TestCase):
             n3.subscribe(['remove'])
 
             kv = client.open("/a/file.txt")
-            kv.put('key1', 'value1')
-            kv.remove('key1')
+            kv.put(b'key1', b'value1')
+            kv.remove(b'key1')
 
             self.assertEqual(Notification('put', b('key1')), n1.get_notification())
             n2_notifs = [n2.get_notification(), n2.get_notification()]
@@ -426,8 +426,8 @@ class TestClient(TestCase):
             n1.unsubscribe(['put'])
             n2.unsubscribe(['remove'])
 
-            kv.put('key1', 'value1')
-            kv.remove('key1')
+            kv.put(b'key1', b'value1')
+            kv.remove(b'key1')
 
             self.assertEqual(Notification('put', b'key1'), n2.get_notification())
             self.assertEqual(Notification('remove', b'key1'), n3.get_notification())


### PR DESCRIPTION
This pull request fix config parser issue according to this [issue](https://github.com/ucbrise/jiffy/issues/38)

Python client tests pass in python 2.7.15

Still need to check if this update works under python 3.6+, or if it is necessary to make the change

The issue is that in python 2.7, the config parser doesn't have the method `__getitem__`
so I will get an error when using 
```python
self.host = config['storage']['host']
```
Config parser has a method `get` which could fix this.
```python
self.host = config.get('storage', 'host')
```

Here is the error log I get when testing python client:
```bash
2: ============================= test session starts ==============================
2: platform darwin -- Python 2.7.15, pytest-3.9.3, py-1.7.0, pluggy-0.8.1 -- /usr/local/opt/python@2/bin/python2.7
2: cachedir: .pytest_cache
2: rootdir: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy, inifile: setup.cfg
2: plugins: cov-2.6.1
2: collecting ... collected 8 items
2: 
2: test/test_client.py::TestClient::test_chain_replication FAILED           [ 12%]
2: test/test_client.py::TestClient::test_close FAILED                       [ 25%]
2: test/test_client.py::TestClient::test_create FAILED                      [ 37%]
2: test/test_client.py::TestClient::test_failures FAILED                    [ 50%]
2: test/test_client.py::TestClient::test_lease_worker FAILED                [ 62%]
2: test/test_client.py::TestClient::test_notifications FAILED               [ 75%]
2: test/test_client.py::TestClient::test_open FAILED                        [ 87%]
2: test/test_client.py::TestClient::test_sync_remove FAILED                 [100%]
2: 
2: =================================== FAILURES ===================================
2: ______________________ TestClient.test_chain_replication _______________________
2: 
2: self = <test.test_client.TestClient testMethod=test_chain_replication>
2: 
2:     def test_chain_replication(self):
2: >       self.start_servers(chain=True)
2: 
2: test/test_client.py:361: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108e19b50>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:05 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:05 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:05 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:05 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:05 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:05 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:05 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:05 INFO main(...) Lease server listening on 127.0.0.1:9091
2: ____________________________ TestClient.test_close _____________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_close>
2: 
2:     def test_close(self):
2: >       self.start_servers()
2: 
2: test/test_client.py:333: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108f64210>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:05 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:05 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:05 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:05 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:05 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:05 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:05 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:05 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:05 ERROR main(...) Lease server failed: Could not bind: Address already in use
2: ____________________________ TestClient.test_create ____________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_create>
2: 
2:     def test_create(self):
2: >       self.start_servers()
2: 
2: test/test_client.py:295: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108f64bd0>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:05 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:05 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:05 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:05 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:05 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:05 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:05 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:05 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:05 ERROR main(...) Block allocation server failed: Could not bind: Address already in use
2: ___________________________ TestClient.test_failures ___________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_failures>
2: 
2:     def test_failures(self):
2:         servers = [self.storage_server_1, self.storage_server_2, self.storage_server_3]
2:         for s in servers:
2: >           self.start_servers(chain=True)
2: 
2: test/test_client.py:374: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108f6f1d0>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:05 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:05 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:05 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:05 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:05 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:05 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:05 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:05 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:05 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:05 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:05 ERROR main(...) Directory server failed: Could not bind: Address already in use
2: _________________________ TestClient.test_lease_worker _________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_lease_worker>
2: 
2:     def test_lease_worker(self):
2: >       self.start_servers()
2: 
2: test/test_client.py:281: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108f64690>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:06 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:06 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:06 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:06 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:06 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:06 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:06 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:06 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:06 ERROR main(...) Lease server failed: Could not bind: Address already in use
2: ________________________ TestClient.test_notifications _________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_notifications>
2: 
2:     def test_notifications(self):
2: >       self.start_servers()
2: 
2: test/test_client.py:401: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x10844d710>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:06 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:06 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:06 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:06 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:06 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:06 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:06 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:06 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:06 ERROR main(...) Directory server failed: Could not bind: Address already in use
2: _____________________________ TestClient.test_open _____________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_open>
2: 
2:     def test_open(self):
2: >       self.start_servers()
2: 
2: test/test_client.py:306: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108432050>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:06 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:06 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:06 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:06 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:06 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:06 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:06 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:06 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:06 ERROR main(...) Block allocation server failed: Could not bind: Address already in use
2: _________________________ TestClient.test_sync_remove __________________________
2: 
2: self = <test.test_client.TestClient testMethod=test_sync_remove>
2: 
2:     def test_sync_remove(self):
2: >       self.start_servers()
2: 
2: test/test_client.py:318: 
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: test/test_client.py:154: in start_servers
2:     self.directory_server.start(directory_executable, directory_conf)
2: _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
2: 
2: self = <test.test_client.DirectoryServer object at 0x108435110>
2: executable = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/../directory/directoryd'
2: conf = '/Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf'
2: 
2:     def start(self, executable, conf):
2:         super(DirectoryServer, self).start(executable, conf)
2:         config = configparser.ConfigParser()
2:         config.read(conf)
2: >       self.host = config['directory']['host']
2: E       AttributeError: ConfigParser instance has no attribute '__getitem__'
2: 
2: test/test_client.py:116: AttributeError
2: --------------------------- Captured stderr teardown ---------------------------
2: 2019-02-02 22:15:06 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
2: 2019-02-02 22:15:06 INFO main(...) config: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/pyjiffy/test/resources/directory.conf
2: 2019-02-02 22:15:06 INFO main(...) directory.host: 127.0.0.1
2: 2019-02-02 22:15:06 INFO main(...) directory.service_port: 9090
2: 2019-02-02 22:15:06 INFO main(...) directory.lease_port: 9091
2: 2019-02-02 22:15:06 INFO main(...) directory.block_port: 9092
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.lease_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) directory.lease.grace_period_ms: 1000
2: 2019-02-02 22:15:06 INFO main(...) Block allocation server listening on 127.0.0.1:9092
2: 2019-02-02 22:15:06 INFO main(...) Directory server listening on 127.0.0.1:9090
2: 2019-02-02 22:15:06 INFO main(...) Lease server listening on 127.0.0.1:9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9091
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9092
2: 2019-02-02 22:15:06 INFO Thrift TServerSocket::listen() BIND 9090
2: 2019-02-02 22:15:06 ERROR main(...) Block allocation server failed: Could not bind: Address already in use
2: =========================== 8 failed in 1.00 seconds ===========================
^Cmake: *** [test] Interrupt: 2
```