### PR TITLE
Fix scaling test[WIP]

### DIFF
--- a/libjiffy/test/auto_scaling_test.cpp
+++ b/libjiffy/test/auto_scaling_test.cpp
@@ -45,7 +45,7 @@ TEST_CASE("auto_scale_up_test", "[directory_service][storage_server][management_
   std::thread dir_serve_thread([&dir_server] { dir_server->serve(); });
   test_utils::wait_till_server_ready(HOST, DIRECTORY_SERVICE_PORT);
 
-  REQUIRE_NOTHROW(t->create("/sandbox/file.txt", "storage", "/tmp"));
+  REQUIRE_NOTHROW(t->create("/sandbox/file.txt", "hashtable", "/tmp"));
 
   // Write data until auto scaling is triggered
   for (std::size_t i = 0; i < 1000; ++i) {
@@ -106,7 +106,7 @@ TEST_CASE("auto_scale_down_test", "[directory_service][storage_server][managemen
   std::thread dir_serve_thread([&dir_server] { dir_server->serve(); });
   test_utils::wait_till_server_ready(HOST, DIRECTORY_SERVICE_PORT);
 
-  REQUIRE_NOTHROW(t->create("/sandbox/file.txt", "storage", "/tmp", 2));
+  REQUIRE_NOTHROW(t->create("/sandbox/file.txt", "hashtable", "/tmp", 2));
 
   // Write some initial data
   for (std::size_t i = 0; i < 1000; ++i) {


### PR DESCRIPTION
There is some issue when I start the auto_scaling_test.

I fixed so that there are no compile errors, but the test log told me that there was no such a type when creating partition. Could you please help me check it out?

test 1
    Start 1: JiffyTest

1: Test command: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/build/libjiffy/jiffy_tests
1: Test timeout computed to be: 1500
1: 2019-02-15 00:35:13 INFO jiffy::storage::partition_manager::register_impl(...) Registered implementation for hashtable
1: 
1: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1: jiffy_tests is a Catch v2.2.1 host application.
1: Run with -? for options
1: 
1: -------------------------------------------------------------------------------
1: auto_scale_up_test
1: -------------------------------------------------------------------------------
1: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/libjiffy/test/auto_scaling_test.cpp:27
1: ...............................................................................
1: 
1: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/libjiffy/test/auto_scaling_test.cpp:27: FAILED:
1: due to unexpected exception with message:
1:   std::bad_alloc
1: 
1: 2019-02-15 00:35:13 INFO jiffy::storage::hash_table_partition::hash_table_partition(...) Partition name: 0_65536
1: 2019-02-15 00:35:13 INFO jiffy::storage::hash_table_partition::hash_table_partition(...) Partition name: 0_65536
1: 2019-02-15 00:35:13 INFO jiffy::storage::block_server::create(...) Creating non-blocking server
1: 2019-02-15 00:35:13 INFO Thrift TSocket::open() connect() <Host: 127.0.0.1 Port: 9091>: Connection refused
1: 2019-02-15 00:35:13 INFO Thrift TNonblockingServer: Serving with 1 io threads.
1: 2019-02-15 00:35:13 INFO Thrift TNonblockingServer: using libevent 2.1.8-beta method kqueue
1: 2019-02-15 00:35:13 INFO Thrift TNonblocking: IO thread #0 registered for listen.
1: 2019-02-15 00:35:13 INFO Thrift TNonblocking: IO thread #0 registered for notify.
1: 2019-02-15 00:35:13 INFO Thrift TNonblocking: IO Thread #0 using high-priority scheduler!
1: 2019-02-15 00:35:13 INFO Thrift TNonblockingServer: IO thread #0 entering loop...
1: 2019-02-15 00:35:13 INFO test_utils::wait_till_server_ready(...) Server @ 127.0.0.1:9091 is live
1: 2019-02-15 00:35:13 INFO Thrift TSocket::open() connect() <Host: 127.0.0.1 Port: 9092>: Connection refused
1: 2019-02-15 00:35:13 INFO test_utils::wait_till_server_ready(...) Server @ 127.0.0.1:9092 is live
1: 2019-02-15 00:35:13 INFO Thrift TSocket::open() connect() <Host: 127.0.0.1 Port: 9090>: Connection refused
1: 2019-02-15 00:35:13 INFO test_utils::wait_till_server_ready(...) Server @ 127.0.0.1:9090 is live
1: 2019-02-15 00:35:13 INFO jiffy::directory::directory_tree::create(...) Creating file /sandbox/file.txt with backing_path=/tmp num_blocks=2, chain_length=1
1: 2019-02-15 00:35:13 INFO jiffy::directory::directory_tree::create_directories(...) Creating directory /sandbox/
1: 2019-02-15 00:35:13 INFO jiffy::storage::storage_manager::create_partition(...) setup partition on 127.0.0.1:9092
1: 2019-02-15 00:35:13 INFO jiffy::storage::hash_table_partition::hash_table_partition(...) Partition name: 0
1: 2019-02-15 00:35:13 INFO jiffy::storage::storage_management_service_handler::create_partition(...) Caught exception: stoi: no conversion
1: -------------------------------------------------------------------------------
1: auto_scale_down_test
1: -------------------------------------------------------------------------------
1: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/libjiffy/test/auto_scaling_test.cpp:88
1: ...............................................................................
1: 
1: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/libjiffy/test/auto_scaling_test.cpp:109: FAILED:
1:   REQUIRE_NOTHROW( t->create("/sandbox/file.txt", "hashtable", "/tmp", 2) )
1: due to unexpected exception with message:
1:   TException - service has thrown: storage_management_exception(msg=stoi: no
1:   conversion)
1: 
1: libc++abi.dylib: terminating
1: /Users/YupengTANG/Documents/GitHub/jiffy-test-fix/jiffy/libjiffy/test/auto_scaling_test.cpp:109: FAILED:
1:   {Unknown expression after the reported line}
1: due to a fatal error condition:
1:   SIGABRT - Abort (abnormal termination) signal
1: 
1: ===============================================================================
1: test cases: 2 | 2 failed
1: assertions: 3 | 3 failed
1: 
1/3 Test #1: JiffyTest ........................Child aborted***Exception:   0.40 sec
test 2
