### PR TITLE
Fix Auto-scaling issue in queue python client

### DIFF
--- a/pyjiffy/jiffy/storage/queue.py
+++ b/pyjiffy/jiffy/storage/queue.py
@@ -21,7 +21,7 @@ class QueueOps:
     out_rate = b('out_rate')
 
     op_types = {enqueue: CommandType.mutator,
-                dequeue: CommandType.accessor,
+                dequeue: CommandType.mutator,
                 read_next: CommandType.accessor,
                 length: CommandType.accessor,
                 in_rate: CommandType.accessor,
@@ -133,7 +133,7 @@ class Queue(DataStructureClient):
             raise ValueError
 
     def add_blocks(self, response, args):
-        if self._block_id(args) >= len(self.block_info.data_blocks) - 1:
+        if self._block_id(args) >= len(self.blocks) - 1:
             if self.auto_scale:
                 block_ids = [bytes_to_str(j) for j in response[1].split(b('!'))]
                 chain = ReplicaChain(block_ids, 0, 0, rpc_storage_mode.rpc_in_memory)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change dequeue to mutator operation and modify the way to check the number of blocks existing in the queue. The previous implementation is wrong because it is checking self.block_info.data_blocks which is not updated as the queue scales.

## How was this patch tested?

Tested here: https://github.com/ucbrise/jiffy/blob/4ec82a117825f2764bb791732b13d53276b49d7e/pyjiffy/test/test_client.py#L441
.
