### PR TITLE
set default test mode to DRAM

### DIFF
--- a/libjiffy/test/jiffy_tests.cpp
+++ b/libjiffy/test/jiffy_tests.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   Catch::Session session;
   log_utils::configure_log_level(log_level::info);
   GlobalOutput.setOutputFunction(log_utils::log_thrift_msg);
-  std::string mode = DRAM;
+  std::string mode = "DRAM";
   std::string pmem_path;
   auto cli = session.cli()
             |Opt(mode, "pmem_mode")

--- a/libjiffy/test/jiffy_tests.cpp
+++ b/libjiffy/test/jiffy_tests.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   Catch::Session session;
   log_utils::configure_log_level(log_level::info);
   GlobalOutput.setOutputFunction(log_utils::log_thrift_msg);
-  std::string mode;
+  std::string mode = DRAM;
   std::string pmem_path;
   auto cli = session.cli()
             |Opt(mode, "pmem_mode")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set default test mode to DRAM so that command 'make test' will not abort.

