### PR TITLE
CMake patches for compilation on Fedora 31

### DIFF
--- a/cmake-modules/FindMemkind.cmake
+++ b/cmake-modules/FindMemkind.cmake
@@ -5,7 +5,7 @@
 # MEMKIND_FOUND - True if memkind found.
 
 find_path(MEMKIND_INCLUDE_DIR
-        NAMES memkind/memkind.h
+        NAMES memkind.h
         HINTS ${MEMKIND_ROOT_DIR}/include)
 
 find_library(MEMKIND_LIBRARY

--- a/jiffy4j/core/pom.xml
+++ b/jiffy4j/core/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+    <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.3.2</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/libjiffy/src/jiffy/directory/block/block_registration_service_handler.h
+++ b/libjiffy/src/jiffy/directory/block/block_registration_service_handler.h
@@ -3,6 +3,7 @@
 
 #include "block_registration_service.h"
 #include "block_allocator.h"
+#include <stdexcept>
 
 namespace jiffy {
 namespace directory {

--- a/libjiffy/src/jiffy/storage/command.h
+++ b/libjiffy/src/jiffy/storage/command.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <string>
 #include <unordered_map>
 
 namespace jiffy {


### PR DESCRIPTION
## What changes were proposed in this pull request?
3 changes made to compile on my machine with Fedora 31, gcc v10.2.1, java openjdk 11.0.10
- Changed lookup path for memkind. When memkind was installed using package manager, it did not create a directory in the include path
- Added maven dependency for javax.annotation, needed for jiffy4j
- Needed includes for string and stdexcept in some header files in libjiffy
## How was this patch tested?
The repo compiled. However, the tests using `make test` fails

## Other issues I found NOT included in this patch
When Thrift was installed using system package manager, CMakelists did not build Thrift AND Boost. However, Boost is a requirement in CMakelists in libjiffy/Cmakelists. I 'fixed' this by uninstalled Thrift from the system and allowing CMake to grab the source and build both Boost and Thrift.

Please review https://ucbrise.github.io/jiffy/contributing/ before opening a pull request.
